### PR TITLE
Rename fan control macro

### DIFF
--- a/include/Pins.h
+++ b/include/Pins.h
@@ -62,7 +62,7 @@
 
         // Output Control Pins
         #define BUZZER_OUT 2        // Buzzer Output Pin
-        #define FAN_CNTROL 3        // Fan Control PWM Pin
+        #define FAN_CONTROL 3        // Fan Control PWM Pin
         #define LED_TLC_RST 17      // TLC59116 Reset Pin
 
 

--- a/src/HandleInputs.cpp
+++ b/src/HandleInputs.cpp
@@ -135,7 +135,7 @@ void initOutputs() {
   pinMode(BUZZER_OUT, OUTPUT);
 
   // Initialise Fan Control Output
-  pinMode(FAN_CNTROL, OUTPUT);
+  pinMode(FAN_CONTROL, OUTPUT);
 
   // Initialise TLC Reset Pin
   pinMode(LED_TLC_RST, OUTPUT);

--- a/src/Temperature.cpp
+++ b/src/Temperature.cpp
@@ -183,7 +183,7 @@ void controlFanSpeed() {
     }
   }
 
-  analogWrite(FAN_CNTROL, pwm);
+  analogWrite(FAN_CONTROL, pwm);
 }
 
 


### PR DESCRIPTION
## Summary
- rename macro `FAN_CNTROL` to `FAN_CONTROL`
- use the new `FAN_CONTROL` macro in fan initialization and temperature control

## Testing
- `platformio run` *(fails: `platformio` not found)*

------
https://chatgpt.com/codex/tasks/task_e_684481b09e388326b074570e992d9a05